### PR TITLE
Add TLS encoding/decoding and some refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,19 @@ sha2 = "0.10.2"
 thiserror = "1.0.31"
 tls_codec = "0.2.0"
 voprf = "0.4.0-pre.4"
-blind-rsa-signatures = "0.13.0"
-pest = "2.2.1"
-pest_derive = "2.2.1"
-tls_codec_derive = "0.2.0"
-
-[dev-dependencies]
 p256 = { version = "0.11", default-features = false, features = [
   "hash2curve",
   "voprf",
 ] }
+blind-rsa-signatures = "0.13.0"
+pest = "2.2.1"
+pest_derive = "2.2.1"
+tls_codec_derive = "0.2.0"
+http = "0.2.8"
+typenum = "1.15.0"
+
+[dev-dependencies]
+
 tokio = { version = "1.20.0", features = ["full"] }
 criterion = { version = "0.3.6", features = ["async_futures", "async_tokio"] }
 

--- a/benches/batched.rs
+++ b/benches/batched.rs
@@ -2,7 +2,6 @@
 mod batched_memory_stores;
 
 use criterion::{async_executor::FuturesExecutor, Criterion};
-use generic_array::ArrayLength;
 use tokio::runtime::Runtime;
 
 use privacypass::{auth::authenticate::TokenChallenge, TokenType};
@@ -25,16 +24,14 @@ async fn issue_batched_token_response(
         .unwrap()
 }
 
-async fn redeem_batched_token<Nk>(
-    mut key_store: batched_memory_stores::MemoryKeyStore,
-    mut nonce_store: batched_memory_stores::MemoryNonceStore,
-    token: privacypass::auth::authorize::Token<Nk>,
-    mut server: privacypass::batched_tokens::server::Server,
-) where
-    Nk: ArrayLength<u8>,
-{
+async fn redeem_batched_token(
+    key_store: batched_memory_stores::MemoryKeyStore,
+    nonce_store: batched_memory_stores::MemoryNonceStore,
+    token: privacypass::batched_tokens::BatchedToken,
+    server: privacypass::batched_tokens::server::Server,
+) {
     server
-        .redeem_token(&mut key_store, &mut nonce_store, token)
+        .redeem_token(&key_store, &nonce_store, token)
         .await
         .unwrap();
 }

--- a/benches/private.rs
+++ b/benches/private.rs
@@ -4,20 +4,19 @@ mod private_memory_stores;
 use criterion::{async_executor::FuturesExecutor, Criterion};
 use generic_array::ArrayLength;
 use tokio::runtime::Runtime;
-use voprf::*;
 
 use privacypass::{auth::authenticate::TokenChallenge, TokenType};
 
 async fn create_private_keypair(
-    mut key_store: private_memory_stores::MemoryKeyStore<Ristretto255>,
-    mut server: privacypass::private_tokens::server::Server<Ristretto255>,
+    key_store: private_memory_stores::MemoryKeyStore,
+    mut server: privacypass::private_tokens::server::Server,
 ) {
-    let _public_key = server.create_keypair(&mut key_store, 1).await.unwrap();
+    let _public_key = server.create_keypair(&key_store, 1).await.unwrap();
 }
 
 async fn issue_private_token_response(
-    key_store: private_memory_stores::MemoryKeyStore<Ristretto255>,
-    mut server: privacypass::private_tokens::server::Server<Ristretto255>,
+    key_store: private_memory_stores::MemoryKeyStore,
+    mut server: privacypass::private_tokens::server::Server,
     token_request: privacypass::private_tokens::TokenRequest,
 ) -> privacypass::private_tokens::TokenResponse {
     server
@@ -27,13 +26,13 @@ async fn issue_private_token_response(
 }
 
 async fn redeem_private_token<Nk: ArrayLength<u8>>(
-    mut key_store: private_memory_stores::MemoryKeyStore<Ristretto255>,
-    mut nonce_store: private_memory_stores::MemoryNonceStore,
+    key_store: private_memory_stores::MemoryKeyStore,
+    nonce_store: private_memory_stores::MemoryNonceStore,
     token: privacypass::auth::authorize::Token<Nk>,
-    mut server: privacypass::private_tokens::server::Server<Ristretto255>,
+    mut server: privacypass::private_tokens::server::Server,
 ) {
     server
-        .redeem_token(&mut key_store, &mut nonce_store, token)
+        .redeem_token(&key_store, &nonce_store, token)
         .await
         .unwrap();
 }
@@ -44,7 +43,7 @@ pub fn criterion_private_benchmark(c: &mut Criterion) {
         b.to_async(FuturesExecutor).iter_with_setup(
             || {
                 let key_store = private_memory_stores::MemoryKeyStore::default();
-                let server = privacypass::private_tokens::server::Server::<Ristretto255>::new();
+                let server = privacypass::private_tokens::server::Server::new();
                 (key_store, server)
             },
             |(key_store, server)| create_private_keypair(key_store, server),
@@ -55,13 +54,12 @@ pub fn criterion_private_benchmark(c: &mut Criterion) {
     c.bench_function("PRIVATE CLIENT: Issue token request", move |b| {
         b.iter_with_setup(
             || {
-                let mut key_store = private_memory_stores::MemoryKeyStore::default();
-                let mut server = privacypass::private_tokens::server::Server::<Ristretto255>::new();
+                let key_store = private_memory_stores::MemoryKeyStore::default();
+                let mut server = privacypass::private_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let public_key =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
-                let client =
-                    privacypass::private_tokens::client::Client::<Ristretto255>::new(1, public_key);
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
+                let client = privacypass::private_tokens::client::Client::new(1, public_key);
                 let challenge = TokenChallenge::new(
                     TokenType::Private,
                     "example.com",
@@ -80,13 +78,12 @@ pub fn criterion_private_benchmark(c: &mut Criterion) {
     c.bench_function("PRIVATE SERVER: Issue token response", move |b| {
         b.to_async(FuturesExecutor).iter_with_setup(
             || {
-                let mut key_store = private_memory_stores::MemoryKeyStore::default();
-                let mut server = privacypass::private_tokens::server::Server::<Ristretto255>::new();
+                let key_store = private_memory_stores::MemoryKeyStore::default();
+                let mut server = privacypass::private_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let public_key =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
-                let mut client =
-                    privacypass::private_tokens::client::Client::<Ristretto255>::new(1, public_key);
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
+                let mut client = privacypass::private_tokens::client::Client::new(1, public_key);
                 let challenge = TokenChallenge::new(
                     TokenType::Private,
                     "example.com",
@@ -106,13 +103,12 @@ pub fn criterion_private_benchmark(c: &mut Criterion) {
     c.bench_function("PRIVATE CLIENT: Issue token", move |b| {
         b.iter_with_setup(
             || {
-                let mut key_store = private_memory_stores::MemoryKeyStore::default();
-                let mut server = privacypass::private_tokens::server::Server::<Ristretto255>::new();
+                let key_store = private_memory_stores::MemoryKeyStore::default();
+                let mut server = privacypass::private_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let public_key =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
-                let mut client =
-                    privacypass::private_tokens::client::Client::<Ristretto255>::new(1, public_key);
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
+                let mut client = privacypass::private_tokens::client::Client::new(1, public_key);
                 let challenge = TokenChallenge::new(
                     TokenType::Private,
                     "example.com",
@@ -138,14 +134,13 @@ pub fn criterion_private_benchmark(c: &mut Criterion) {
     c.bench_function("PRIVATE SERVER: Redeem token", move |b| {
         b.to_async(FuturesExecutor).iter_with_setup(
             || {
-                let mut key_store = private_memory_stores::MemoryKeyStore::default();
+                let key_store = private_memory_stores::MemoryKeyStore::default();
                 let nonce_store = private_memory_stores::MemoryNonceStore::default();
-                let mut server = privacypass::private_tokens::server::Server::<Ristretto255>::new();
+                let mut server = privacypass::private_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let public_key =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
-                let mut client =
-                    privacypass::private_tokens::client::Client::<Ristretto255>::new(1, public_key);
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
+                let mut client = privacypass::private_tokens::client::Client::new(1, public_key);
                 let challenge = TokenChallenge::new(
                     TokenType::Private,
                     "example.com",

--- a/benches/public.rs
+++ b/benches/public.rs
@@ -8,10 +8,10 @@ use tokio::runtime::Runtime;
 use privacypass::{auth::authenticate::TokenChallenge, TokenType};
 
 async fn create_public_keypair(
-    mut key_store: public_memory_stores::MemoryKeyStore,
+    key_store: public_memory_stores::MemoryKeyStore,
     mut server: privacypass::public_tokens::server::Server,
 ) {
-    let _public_key = server.create_keypair(&mut key_store, 1).await.unwrap();
+    let _public_key = server.create_keypair(&key_store, 1).await.unwrap();
 }
 
 async fn issue_public_token_response(
@@ -26,13 +26,13 @@ async fn issue_public_token_response(
 }
 
 async fn redeem_public_token<Nk: ArrayLength<u8>>(
-    mut key_store: public_memory_stores::MemoryKeyStore,
-    mut nonce_store: public_memory_stores::MemoryNonceStore,
+    key_store: public_memory_stores::MemoryKeyStore,
+    nonce_store: public_memory_stores::MemoryNonceStore,
     token: privacypass::auth::authorize::Token<Nk>,
     mut server: privacypass::public_tokens::server::Server,
 ) {
     server
-        .redeem_token(&mut key_store, &mut nonce_store, token)
+        .redeem_token(&key_store, &nonce_store, token)
         .await
         .unwrap();
 }
@@ -54,11 +54,11 @@ pub fn criterion_public_benchmark(c: &mut Criterion) {
     c.bench_function("PUBLIC CLIENT: Issue token request", move |b| {
         b.iter_with_setup(
             || {
-                let mut key_store = public_memory_stores::MemoryKeyStore::default();
+                let key_store = public_memory_stores::MemoryKeyStore::default();
                 let mut server = privacypass::public_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let key_pair =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
                 let client = privacypass::public_tokens::client::Client::new(1, key_pair.pk);
                 let challenge = TokenChallenge::new(
                     TokenType::Public,
@@ -78,11 +78,11 @@ pub fn criterion_public_benchmark(c: &mut Criterion) {
     c.bench_function("PUBLIC SERVER: Issue token response", move |b| {
         b.to_async(FuturesExecutor).iter_with_setup(
             || {
-                let mut key_store = public_memory_stores::MemoryKeyStore::default();
+                let key_store = public_memory_stores::MemoryKeyStore::default();
                 let mut server = privacypass::public_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let key_pair =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
                 let mut client = privacypass::public_tokens::client::Client::new(1, key_pair.pk);
                 let challenge = TokenChallenge::new(
                     TokenType::Public,
@@ -103,11 +103,11 @@ pub fn criterion_public_benchmark(c: &mut Criterion) {
     c.bench_function("PUBLIC CLIENT: Issue token", move |b| {
         b.iter_with_setup(
             || {
-                let mut key_store = public_memory_stores::MemoryKeyStore::default();
+                let key_store = public_memory_stores::MemoryKeyStore::default();
                 let mut server = privacypass::public_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let key_pair =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
                 let mut client = privacypass::public_tokens::client::Client::new(1, key_pair.pk);
                 let challenge = TokenChallenge::new(
                     TokenType::Public,
@@ -134,12 +134,12 @@ pub fn criterion_public_benchmark(c: &mut Criterion) {
     c.bench_function("PUBLIC SERVER: Redeem token", move |b| {
         b.to_async(FuturesExecutor).iter_with_setup(
             || {
-                let mut key_store = public_memory_stores::MemoryKeyStore::default();
+                let key_store = public_memory_stores::MemoryKeyStore::default();
                 let nonce_store = public_memory_stores::MemoryNonceStore::default();
                 let mut server = privacypass::public_tokens::server::Server::new();
                 let rt = Runtime::new().unwrap();
                 let key_pair =
-                    rt.block_on(async { server.create_keypair(&mut key_store, 1).await.unwrap() });
+                    rt.block_on(async { server.create_keypair(&key_store, 1).await.unwrap() });
                 let mut client = privacypass::public_tokens::client::Client::new(1, key_pair.pk);
                 let challenge = TokenChallenge::new(
                     TokenType::Public,

--- a/src/batched_tokens/mod.rs
+++ b/src/batched_tokens/mod.rs
@@ -1,41 +1,22 @@
 pub mod client;
 pub mod server;
 
+use std::io::Write;
+use thiserror::*;
+use tls_codec::{Deserialize, Serialize, Size, TlsVecU16};
+use typenum::U64;
 pub use voprf::*;
 
-use crate::{ChallengeDigest, KeyId, Nonce, TokenType};
+use crate::{auth::authorize::Token, Nonce, TokenType};
 
-pub struct TokenInput {
-    pub token_type: TokenType,
-    pub nonce: Nonce,
-    pub challenge_digest: ChallengeDigest,
-    pub key_id: KeyId,
-}
+pub type BatchedToken = Token<U64>;
 
-impl TokenInput {
-    pub fn new(
-        token_type: TokenType,
-        nonce: Nonce,
-        challenge_digest: ChallengeDigest,
-        key_id: KeyId,
-    ) -> Self {
-        Self {
-            token_type,
-            nonce,
-            challenge_digest,
-            key_id,
-        }
-    }
+pub type PublicKey = <Ristretto255 as Group>::Elem;
 
-    pub fn serialize(&self) -> Vec<u8> {
-        // token_input = concat(0x0003, nonce, challenge_digest, key_id)
-        let mut token_input: Vec<u8> = Vec::new();
-        token_input.extend_from_slice((self.token_type as u16).to_be_bytes().as_slice());
-        token_input.extend_from_slice(self.nonce.as_slice());
-        token_input.extend_from_slice(self.challenge_digest.as_slice());
-        token_input.push(self.key_id);
-        token_input
-    }
+#[derive(Error, Debug)]
+pub enum SerializationError {
+    #[error("Invalid serialized data")]
+    InvalidData,
 }
 
 // struct {
@@ -43,11 +24,11 @@ impl TokenInput {
 // } BlindedElement;
 
 pub struct BlindedElement {
-    blinded_element: Vec<u8>,
+    blinded_element: [u8; 32],
 }
 
 // struct {
-//     uint16_t token_type = 0x0003;
+//     uint16_t token_type = 0xF91A;
 //     uint8_t token_key_id;
 //     BlindedElement blinded_element[Nr];
 // } TokenRequest;
@@ -55,7 +36,14 @@ pub struct BlindedElement {
 pub struct TokenRequest {
     token_type: TokenType,
     token_key_id: u8,
-    blinded_elements: Vec<BlindedElement>,
+    blinded_elements: TlsVecU16<BlindedElement>,
+}
+
+impl TokenRequest {
+    /// Returns the number of blinded elements
+    pub fn nr(&self) -> usize {
+        self.blinded_elements.len()
+    }
 }
 
 // struct {
@@ -63,7 +51,7 @@ pub struct TokenRequest {
 // } EvaluatedElement;
 
 pub struct EvaluatedElement {
-    evaluated_element: Vec<u8>,
+    evaluated_element: [u8; 32],
 }
 
 // struct {
@@ -72,6 +60,147 @@ pub struct EvaluatedElement {
 //  } TokenResponse;
 
 pub struct TokenResponse {
-    evaluated_elements: Vec<EvaluatedElement>,
-    evaluated_proof: Vec<u8>,
+    evaluated_elements: TlsVecU16<EvaluatedElement>,
+    evaluated_proof: [u8; 64],
+}
+
+impl TokenResponse {
+    /// Create a new TokenResponse from a byte slice.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
+        let mut bytes = bytes;
+        Self::tls_deserialize(&mut bytes).map_err(|_| SerializationError::InvalidData)
+    }
+}
+
+// === TLS codecs ===
+
+impl Size for BlindedElement {
+    fn tls_serialized_len(&self) -> usize {
+        32
+    }
+}
+
+impl Serialize for BlindedElement {
+    fn tls_serialize<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> std::result::Result<usize, tls_codec::Error> {
+        Ok(writer.write(&self.blinded_element)?)
+    }
+}
+
+impl Deserialize for BlindedElement {
+    fn tls_deserialize<R: std::io::Read>(
+        bytes: &mut R,
+    ) -> std::result::Result<BlindedElement, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let mut blinded_element = [0u8; 32];
+        bytes.read_exact(&mut blinded_element)?;
+        Ok(BlindedElement { blinded_element })
+    }
+}
+
+impl Size for EvaluatedElement {
+    fn tls_serialized_len(&self) -> usize {
+        32
+    }
+}
+
+impl Serialize for EvaluatedElement {
+    fn tls_serialize<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> std::result::Result<usize, tls_codec::Error> {
+        Ok(writer.write(&self.evaluated_element)?)
+    }
+}
+
+impl Deserialize for EvaluatedElement {
+    fn tls_deserialize<R: std::io::Read>(
+        bytes: &mut R,
+    ) -> std::result::Result<EvaluatedElement, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let mut evaluated_element = [0u8; 32];
+        bytes.read_exact(&mut evaluated_element)?;
+        Ok(EvaluatedElement { evaluated_element })
+    }
+}
+
+impl Size for TokenRequest {
+    fn tls_serialized_len(&self) -> usize {
+        self.token_type.tls_serialized_len()
+            + self.token_key_id.tls_serialized_len()
+            + self
+                .blinded_elements
+                .iter()
+                .map(|x| x.tls_serialized_len())
+                .sum::<usize>()
+    }
+}
+
+impl Serialize for TokenRequest {
+    fn tls_serialize<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> std::result::Result<usize, tls_codec::Error> {
+        Ok(self.token_type.tls_serialize(writer)?
+            + self.token_key_id.tls_serialize(writer)?
+            + self.blinded_elements.tls_serialize(writer)?)
+    }
+}
+
+impl Deserialize for TokenRequest {
+    fn tls_deserialize<R: std::io::Read>(
+        bytes: &mut R,
+    ) -> std::result::Result<TokenRequest, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let token_type = TokenType::tls_deserialize(bytes)?;
+        let token_key_id = u8::tls_deserialize(bytes)?;
+        let blinded_elements = TlsVecU16::tls_deserialize(bytes)?;
+
+        Ok(TokenRequest {
+            token_type,
+            token_key_id,
+            blinded_elements,
+        })
+    }
+}
+
+impl Size for TokenResponse {
+    fn tls_serialized_len(&self) -> usize {
+        self.evaluated_elements.tls_serialized_len() + self.evaluated_proof.tls_serialized_len()
+    }
+}
+
+impl Serialize for TokenResponse {
+    fn tls_serialize<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> std::result::Result<usize, tls_codec::Error> {
+        Ok(self.evaluated_elements.tls_serialize(writer)?
+            + self.evaluated_proof.tls_serialize(writer)?)
+    }
+}
+
+impl Deserialize for TokenResponse {
+    fn tls_deserialize<R: std::io::Read>(
+        bytes: &mut R,
+    ) -> std::result::Result<TokenResponse, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let evaluated_elements = TlsVecU16::tls_deserialize(bytes)?;
+        let mut evaluated_proof = [0u8; 64];
+        bytes.read_exact(&mut evaluated_proof)?;
+        Ok(TokenResponse {
+            evaluated_elements,
+            evaluated_proof,
+        })
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,14 @@ pub mod public_tokens;
 use async_trait::async_trait;
 use tls_codec_derive::{TlsDeserialize, TlsSerialize, TlsSize};
 
+pub use tls_codec::{Deserialize, Serialize};
+
 #[derive(TlsSize, TlsSerialize, TlsDeserialize, Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u16)]
 pub enum TokenType {
     Private = 1,
     Public = 2,
-    Batched = 3,
+    Batched = 0xF91A,
 }
 
 pub type KeyId = u8;
@@ -23,5 +25,38 @@ pub trait NonceStore {
     /// Returns `true` if the nonce exists in the nonce store and `false` otherwise.
     async fn exists(&self, nonce: &Nonce) -> bool;
     /// Inserts a new nonce in the nonce store.
-    async fn insert(&mut self, nonce: Nonce);
+    async fn insert(&self, nonce: Nonce);
+}
+
+pub(crate) struct TokenInput {
+    token_type: TokenType,
+    nonce: Nonce,
+    challenge_digest: ChallengeDigest,
+    key_id: KeyId,
+}
+
+impl TokenInput {
+    pub fn new(
+        token_type: TokenType,
+        nonce: Nonce,
+        challenge_digest: ChallengeDigest,
+        key_id: KeyId,
+    ) -> Self {
+        Self {
+            token_type,
+            nonce,
+            challenge_digest,
+            key_id,
+        }
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        // token_input = concat(0xXXXX, nonce, challenge_digest, key_id)
+        let mut token_input: Vec<u8> = Vec::new();
+        token_input.extend_from_slice((self.token_type as u16).to_be_bytes().as_slice());
+        token_input.extend_from_slice(self.nonce.as_slice());
+        token_input.extend_from_slice(self.challenge_digest.as_slice());
+        token_input.push(self.key_id);
+        token_input
+    }
 }

--- a/src/private_tokens/mod.rs
+++ b/src/private_tokens/mod.rs
@@ -1,41 +1,23 @@
 pub mod client;
 pub mod server;
 
+use p256::NistP256;
+use std::io::Write;
+use thiserror::*;
+use tls_codec::{Deserialize, Serialize, Size};
+use typenum::U32;
 pub use voprf::*;
 
-use crate::{KeyId, Nonce, TokenType};
+use crate::{auth::authorize::Token, Nonce, TokenType};
 
-pub struct TokenInput {
-    pub token_type: TokenType,
-    pub nonce: Nonce,
-    pub challenge_digest: Vec<u8>,
-    pub key_id: KeyId,
-}
+pub type PrivateToken = Token<U32>;
 
-impl TokenInput {
-    pub fn new(
-        token_type: TokenType,
-        nonce: Nonce,
-        challenge_digest: Vec<u8>,
-        key_id: KeyId,
-    ) -> Self {
-        Self {
-            token_type,
-            nonce,
-            challenge_digest,
-            key_id,
-        }
-    }
+pub type PublicKey = <NistP256 as Group>::Elem;
 
-    pub fn serialize(&self) -> Vec<u8> {
-        // token_input = concat(0x0001, nonce, challenge_digest, key_id)
-        let mut token_input: Vec<u8> = Vec::new();
-        token_input.extend_from_slice((self.token_type as u16).to_be_bytes().as_slice());
-        token_input.extend_from_slice(self.nonce.as_slice());
-        token_input.extend_from_slice(self.challenge_digest.as_slice());
-        token_input.push(self.key_id);
-        token_input
-    }
+#[derive(Error, Debug)]
+pub enum SerializationError {
+    #[error("Invalid serialized data")]
+    InvalidData,
 }
 
 // struct {
@@ -47,7 +29,7 @@ impl TokenInput {
 pub struct TokenRequest {
     token_type: TokenType,
     token_key_id: u8,
-    blinded_msg: Vec<u8>,
+    blinded_msg: [u8; 33],
 }
 
 // struct {
@@ -56,6 +38,90 @@ pub struct TokenRequest {
 //  } TokenResponse;
 
 pub struct TokenResponse {
-    evaluate_msg: Vec<u8>,
-    evaluate_proof: Vec<u8>,
+    evaluate_msg: [u8; 33],
+    evaluate_proof: [u8; 64],
+}
+
+impl TokenResponse {
+    /// Create a new TokenResponse from a byte slice.
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, SerializationError> {
+        let mut bytes = bytes;
+        Self::tls_deserialize(&mut bytes).map_err(|_| SerializationError::InvalidData)
+    }
+}
+
+// === TLS codecs ===
+
+impl Size for TokenRequest {
+    fn tls_serialized_len(&self) -> usize {
+        self.token_type.tls_serialized_len()
+            + self.token_key_id.tls_serialized_len()
+            + self.blinded_msg.len()
+    }
+}
+
+impl Serialize for TokenRequest {
+    fn tls_serialize<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> std::result::Result<usize, tls_codec::Error> {
+        Ok(self.token_type.tls_serialize(writer)?
+            + self.token_key_id.tls_serialize(writer)?
+            + writer.write(&self.blinded_msg)?)
+    }
+}
+
+impl Deserialize for TokenRequest {
+    fn tls_deserialize<R: std::io::Read>(
+        bytes: &mut R,
+    ) -> std::result::Result<TokenRequest, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let token_type = TokenType::tls_deserialize(bytes)?;
+        let token_key_id = u8::tls_deserialize(bytes)?;
+        let mut blinded_msg = [0u8; 33];
+        bytes.read_exact(&mut blinded_msg)?;
+
+        Ok(TokenRequest {
+            token_type,
+            token_key_id,
+            blinded_msg,
+        })
+    }
+}
+
+impl Size for TokenResponse {
+    fn tls_serialized_len(&self) -> usize {
+        self.evaluate_msg.len() + self.evaluate_proof.len()
+    }
+}
+
+impl Serialize for TokenResponse {
+    fn tls_serialize<W: Write>(
+        &self,
+        writer: &mut W,
+    ) -> std::result::Result<usize, tls_codec::Error> {
+        Ok(writer.write(&self.evaluate_msg)? + writer.write(&self.evaluate_proof)?)
+    }
+}
+
+impl Deserialize for TokenResponse {
+    fn tls_deserialize<R: std::io::Read>(
+        bytes: &mut R,
+    ) -> std::result::Result<TokenResponse, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let mut evaluate_msg = [0u8; 33];
+        bytes.read_exact(&mut evaluate_msg)?;
+
+        let mut evaluate_proof = [0u8; 64];
+        bytes.read_exact(&mut evaluate_proof)?;
+
+        Ok(TokenResponse {
+            evaluate_msg,
+            evaluate_proof,
+        })
+    }
 }

--- a/src/public_tokens/client.rs
+++ b/src/public_tokens/client.rs
@@ -5,10 +5,10 @@ use thiserror::*;
 
 use crate::{
     auth::{authenticate::TokenChallenge, authorize::Token},
-    ChallengeDigest, TokenType,
+    ChallengeDigest, TokenInput, TokenType,
 };
 
-use super::{Nonce, TokenInput, TokenRequest, TokenResponse};
+use super::{Nonce, TokenRequest, TokenResponse};
 
 pub struct TokenState {
     blinding_result: BlindingResult,

--- a/src/public_tokens/mod.rs
+++ b/src/public_tokens/mod.rs
@@ -1,40 +1,7 @@
 pub mod client;
 pub mod server;
 
-use crate::{ChallengeDigest, KeyId, Nonce, TokenType};
-
-pub struct TokenInput {
-    pub token_type: TokenType,
-    pub nonce: Nonce,
-    pub challenge_digest: ChallengeDigest,
-    pub key_id: KeyId,
-}
-
-impl TokenInput {
-    pub fn new(
-        token_type: TokenType,
-        nonce: Nonce,
-        challenge_digest: ChallengeDigest,
-        key_id: KeyId,
-    ) -> Self {
-        Self {
-            token_type,
-            nonce,
-            challenge_digest,
-            key_id,
-        }
-    }
-
-    pub fn serialize(&self) -> Vec<u8> {
-        // token_input = concat(0x0001, nonce, challenge_digest, key_id)
-        let mut token_input: Vec<u8> = Vec::new();
-        token_input.extend_from_slice((self.token_type as u16).to_be_bytes().as_slice());
-        token_input.extend_from_slice(self.nonce.as_slice());
-        token_input.extend_from_slice(self.challenge_digest.as_slice());
-        token_input.push(self.key_id);
-        token_input
-    }
-}
+use crate::{Nonce, TokenType};
 
 // struct {
 //     uint16_t token_type = 0x0002;

--- a/tests/batched_memory_stores.rs
+++ b/tests/batched_memory_stores.rs
@@ -8,17 +8,19 @@ use privacypass::{KeyId, Nonce, NonceStore};
 
 #[derive(Default)]
 pub struct MemoryNonceStore {
-    nonces: HashSet<Nonce>,
+    nonces: Mutex<HashSet<Nonce>>,
 }
 
 #[async_trait]
 impl NonceStore for MemoryNonceStore {
     async fn exists(&self, nonce: &Nonce) -> bool {
-        self.nonces.contains(nonce)
+        let nonces = self.nonces.lock().await;
+        nonces.contains(nonce)
     }
 
-    async fn insert(&mut self, nonce: Nonce) {
-        self.nonces.insert(nonce);
+    async fn insert(&self, nonce: Nonce) {
+        let mut nonces = self.nonces.lock().await;
+        nonces.insert(nonce);
     }
 }
 
@@ -29,7 +31,7 @@ pub struct MemoryKeyStore {
 
 #[async_trait]
 impl KeyStore for MemoryKeyStore {
-    async fn insert(&mut self, key_id: KeyId, server: VoprfServer<Ristretto255>) {
+    async fn insert(&self, key_id: KeyId, server: VoprfServer<Ristretto255>) {
         let mut keys = self.keys.lock().await;
         keys.insert(key_id, server);
     }

--- a/tests/batched_tokens.rs
+++ b/tests/batched_tokens.rs
@@ -15,7 +15,7 @@ async fn batched_tokens_cycle() {
 
     // Server: Instantiate in-memory keystore and nonce store.
     let mut key_store = MemoryKeyStore::default();
-    let mut nonce_store = MemoryNonceStore::default();
+    let nonce_store = MemoryNonceStore::default();
 
     // Server: Create server
     let mut server = Server::new();
@@ -54,7 +54,7 @@ async fn batched_tokens_cycle() {
     // Server: Redeem the token
     for token in &tokens {
         assert!(server
-            .redeem_token(&mut key_store, &mut nonce_store, token.clone())
+            .redeem_token(&key_store, &nonce_store, token.clone())
             .await
             .is_ok());
     }
@@ -63,7 +63,7 @@ async fn batched_tokens_cycle() {
     for token in &tokens {
         assert_eq!(
             server
-                .redeem_token(&mut key_store, &mut nonce_store, token.clone())
+                .redeem_token(&key_store, &nonce_store, token.clone())
                 .await,
             Err(RedeemTokenError::DoubleSpending)
         );

--- a/tests/private_memory_stores.rs
+++ b/tests/private_memory_stores.rs
@@ -1,9 +1,5 @@
 use async_trait::async_trait;
-use sha2::digest::{
-    core_api::BlockSizeUser,
-    typenum::{IsLess, IsLessOrEqual, U256},
-    OutputSizeUser,
-};
+use p256::NistP256;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::Mutex;
 use voprf::*;
@@ -13,43 +9,35 @@ use privacypass::{KeyId, Nonce, NonceStore};
 
 #[derive(Default)]
 pub struct MemoryNonceStore {
-    nonces: HashSet<Nonce>,
+    nonces: Mutex<HashSet<Nonce>>,
 }
 
 #[async_trait]
 impl NonceStore for MemoryNonceStore {
     async fn exists(&self, nonce: &Nonce) -> bool {
-        self.nonces.contains(nonce)
+        let nonces = self.nonces.lock().await;
+        nonces.contains(nonce)
     }
 
-    async fn insert(&mut self, nonce: Nonce) {
-        self.nonces.insert(nonce);
+    async fn insert(&self, nonce: Nonce) {
+        let mut nonces = self.nonces.lock().await;
+        nonces.insert(nonce);
     }
 }
 
 #[derive(Default)]
-pub struct MemoryKeyStore<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
-    keys: Mutex<HashMap<KeyId, VoprfServer<CS>>>,
+pub struct MemoryKeyStore {
+    keys: Mutex<HashMap<KeyId, VoprfServer<NistP256>>>,
 }
 
 #[async_trait]
-impl<CS: CipherSuite> KeyStore<CS> for MemoryKeyStore<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    <CS::Group as Group>::Scalar: Send,
-    <CS::Group as Group>::Elem: Send,
-{
-    async fn insert(&mut self, key_id: KeyId, server: VoprfServer<CS>) {
+impl KeyStore for MemoryKeyStore {
+    async fn insert(&self, key_id: KeyId, server: VoprfServer<NistP256>) {
         let mut keys = self.keys.lock().await;
         keys.insert(key_id, server);
     }
 
-    async fn get(&self, key_id: &KeyId) -> Option<VoprfServer<CS>> {
+    async fn get(&self, key_id: &KeyId) -> Option<VoprfServer<NistP256>> {
         self.keys.lock().await.get(key_id).cloned()
     }
 }

--- a/tests/public_memory_stores.rs
+++ b/tests/public_memory_stores.rs
@@ -7,17 +7,19 @@ use privacypass::{public_tokens::server::*, KeyId, Nonce, NonceStore};
 
 #[derive(Default)]
 pub struct MemoryNonceStore {
-    nonces: HashSet<Nonce>,
+    nonces: Mutex<HashSet<Nonce>>,
 }
 
 #[async_trait]
 impl NonceStore for MemoryNonceStore {
     async fn exists(&self, nonce: &Nonce) -> bool {
-        self.nonces.contains(nonce)
+        let nonces = self.nonces.lock().await;
+        nonces.contains(nonce)
     }
 
-    async fn insert(&mut self, nonce: Nonce) {
-        self.nonces.insert(nonce);
+    async fn insert(&self, nonce: Nonce) {
+        let mut nonces = self.nonces.lock().await;
+        nonces.insert(nonce);
     }
 }
 
@@ -28,7 +30,7 @@ pub struct MemoryKeyStore {
 
 #[async_trait]
 impl KeyStore for MemoryKeyStore {
-    async fn insert(&mut self, key_id: KeyId, key_pair: KeyPair) {
+    async fn insert(&self, key_id: KeyId, key_pair: KeyPair) {
         let mut keys = self.keys.lock().await;
         keys.insert(key_id, key_pair);
     }

--- a/tests/public_tokens.rs
+++ b/tests/public_tokens.rs
@@ -11,14 +11,14 @@ use privacypass::{
 #[tokio::test]
 async fn public_tokens_cycle() {
     // Server: Instantiate in-memory keystore and nonce store.
-    let mut key_store = MemoryKeyStore::default();
-    let mut nonce_store = MemoryNonceStore::default();
+    let key_store = MemoryKeyStore::default();
+    let nonce_store = MemoryNonceStore::default();
 
     // Server: Create server
     let mut server = Server::new();
 
     // Server: Create a new keypair
-    let key_pair = server.create_keypair(&mut key_store, 1).await.unwrap();
+    let key_pair = server.create_keypair(&key_store, 1).await.unwrap();
 
     // Client: Create client
     let mut client = Client::new(1, key_pair.pk);
@@ -48,14 +48,14 @@ async fn public_tokens_cycle() {
 
     // Server: Redeem the token
     assert!(server
-        .redeem_token(&mut key_store, &mut nonce_store, token.clone())
+        .redeem_token(&key_store, &nonce_store, token.clone())
         .await
         .is_ok());
 
     // Server: Test double spend protection
     assert_eq!(
         server
-            .redeem_token(&mut key_store, &mut nonce_store, token)
+            .redeem_token(&key_store, &nonce_store, token)
             .await,
         Err(RedeemTokenError::DoubleSpending)
     );


### PR DESCRIPTION
This PR makes the following changes:
 - Introduce TLS encoding/decoding
 - Use P256 for private tokens for now
 - Require inner mutability for store traits
 - Introduce HTTP headers
 - Some refactoring