### PR TITLE
Parse URL safe base64 encoding in header values

### DIFF
--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -24,7 +24,7 @@ pub(crate) fn parse_u32(input: &str) -> Result<u32, std::num::ParseIntError> {
 }
 
 pub(crate) fn base64_char(input: &str) -> IResult<&str, &str> {
-    nom::bytes::complete::is_a("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=")(
+    nom::bytes::complete::is_a("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=")(
         input,
     )
 }


### PR DESCRIPTION
Errata from #23. Parsing still expected the standard base64 alphabet so base64url values were rejected.