### PR TITLE
Downgrade `tls_codec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8.5"
 serde = "1"
 sha2 = "0.10.2"
 thiserror = "1"
-tls_codec = { version = "0.4.2-pre.1", git = "https://github.com/rustcrypto/formats" }
+tls_codec = { version = "0.4.1" }
 tls_codec_derive = "0.4.1"
 voprf = { version = "0.5", features = ["serde"] }
 p384 = { version = "0.13.0", default-features = false, features = [


### PR DESCRIPTION
Downgrades `tls_codec` for compatibility with OpenMLS v0.6.