### PR TITLE
chore: Make the API a little easier to use

### DIFF
--- a/src/amortized_tokens/request.rs
+++ b/src/amortized_tokens/request.rs
@@ -103,7 +103,7 @@ impl<CS: PPCipherSuite> AmortizedBatchTokenRequest<CS> {
             .digest()
             .map_err(|_| IssueTokenRequestError::InvalidTokenChallenge)?;
 
-        let token_key_id = public_key_to_token_key_id::<CS::Group>(&public_key);
+        let token_key_id = public_key_to_token_key_id::<CS>(&public_key);
 
         let mut clients = Vec::with_capacity(nonces.len());
         let mut token_inputs = Vec::with_capacity(nonces.len());

--- a/src/amortized_tokens/server.rs
+++ b/src/amortized_tokens/server.rs
@@ -65,9 +65,8 @@ impl<CS: PPCipherSuite> Server<CS> {
         let server = VoprfServer::<CS>::new_from_seed(seed, info)
             .map_err(|_| CreateKeypairError::SeedError)?;
         let public_key = server.get_public_key();
-        let truncated_token_key_id = truncate_token_key_id(
-            &public_key_to_token_key_id::<CS::Group>(&server.get_public_key()),
-        );
+        let truncated_token_key_id =
+            truncate_token_key_id(&public_key_to_token_key_id::<CS>(&server.get_public_key()));
         key_store.insert(truncated_token_key_id, server).await;
         Ok(public_key)
     }
@@ -190,7 +189,7 @@ impl<CS: PPCipherSuite> Server<CS> {
         let server = VoprfServer::<CS>::new_with_key(private_key)
             .map_err(|_| CreateKeypairError::SeedError)?;
         let public_key = server.get_public_key();
-        let token_key_id = public_key_to_token_key_id::<CS::Group>(&server.get_public_key());
+        let token_key_id = public_key_to_token_key_id::<CS>(&server.get_public_key());
         key_store
             .insert(truncate_token_key_id(&token_key_id), server)
             .await;
@@ -223,7 +222,7 @@ mod tests {
     {
         use crate::common::private::{deserialize_public_key, serialize_public_key};
 
-        let bytes = serialize_public_key::<CS::Group>(pk);
+        let bytes = serialize_public_key::<CS>(pk);
         let pk2 = deserialize_public_key::<CS>(&bytes).unwrap();
         assert_eq!(pk, pk2);
     }

--- a/src/common/private.rs
+++ b/src/common/private.rs
@@ -9,20 +9,24 @@ use crate::{PPCipherSuite, TokenKeyId, TruncatedTokenKeyId, truncate_token_key_i
 pub type PublicKey<CS> = <<CS as CipherSuite>::Group as Group>::Elem;
 
 /// Convert a public key to a token key ID.
-pub fn public_key_to_truncated_token_key_id<G: Group>(public_key: &G::Elem) -> TruncatedTokenKeyId {
-    truncate_token_key_id(&public_key_to_token_key_id::<G>(public_key))
+pub fn public_key_to_truncated_token_key_id<CS: PPCipherSuite>(
+    public_key: &<CS::Group as Group>::Elem,
+) -> TruncatedTokenKeyId {
+    truncate_token_key_id(&public_key_to_token_key_id::<CS>(public_key))
 }
 
-pub(crate) fn public_key_to_token_key_id<G: Group>(public_key: &G::Elem) -> TokenKeyId {
-    let public_key = serialize_public_key::<G>(*public_key);
+pub(crate) fn public_key_to_token_key_id<CS: PPCipherSuite>(
+    public_key: &<CS::Group as Group>::Elem,
+) -> TokenKeyId {
+    let public_key = serialize_public_key::<CS>(*public_key);
 
     Sha256::digest(public_key).into()
 }
 
 /// Serializes a public key.
 #[must_use]
-pub fn serialize_public_key<G: Group>(public_key: G::Elem) -> Vec<u8> {
-    G::serialize_elem(public_key).to_vec()
+pub fn serialize_public_key<CS: PPCipherSuite>(public_key: <CS::Group as Group>::Elem) -> Vec<u8> {
+    <CS::Group as Group>::serialize_elem(public_key).to_vec()
 }
 
 /// Deserializes a public key from a slice of bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,12 @@ pub use voprf::{Group, VoprfServer};
 
 /// Trait for a cipher suite that can be used with the Privacy Pass protocol.
 pub trait PPCipherSuite:
-    CipherSuite<Group: Group<Elem: Send + Sync, Scalar: Send + Sync>> + PartialEq + Debug + Clone
+    CipherSuite<Group: Group<Elem: Send + Sync, Scalar: Send + Sync>>
+    + PartialEq
+    + Debug
+    + Clone
+    + Send
+    + Sync
 {
     /// Returns the token type for the cipher suite.
     fn token_type() -> TokenType {
@@ -53,6 +58,8 @@ impl<C> PPCipherSuite for C where
         + PartialEq
         + Debug
         + Clone
+        + Send
+        + Sync
 {
 }
 

--- a/src/private_tokens/request.rs
+++ b/src/private_tokens/request.rs
@@ -76,7 +76,7 @@ impl<CS: PPCipherSuite> TokenRequest<CS> {
             .digest()
             .map_err(|_| IssueTokenRequestError::InvalidTokenChallenge)?;
 
-        let token_key_id = public_key_to_token_key_id::<CS::Group>(&public_key);
+        let token_key_id = public_key_to_token_key_id::<CS>(&public_key);
 
         // nonce = random(32)
         // challenge_digest = SHA256(challenge)

--- a/src/private_tokens/server.rs
+++ b/src/private_tokens/server.rs
@@ -58,9 +58,8 @@ impl<CS: PPCipherSuite> Server<CS> {
         let server = VoprfServer::<CS>::new_from_seed(seed, info)
             .map_err(|_| CreateKeypairError::SeedError)?;
         let public_key = server.get_public_key();
-        let truncated_token_key_id = truncate_token_key_id(
-            &public_key_to_token_key_id::<CS::Group>(&server.get_public_key()),
-        );
+        let truncated_token_key_id =
+            truncate_token_key_id(&public_key_to_token_key_id::<CS>(&server.get_public_key()));
         key_store.insert(truncated_token_key_id, server).await;
         Ok(public_key)
     }
@@ -157,9 +156,8 @@ impl<CS: PPCipherSuite> Server<CS> {
         let server = VoprfServer::<CS>::new_with_key(private_key)
             .map_err(|_| CreateKeypairError::SeedError)?;
         let public_key = server.get_public_key();
-        let truncated_token_key_id = truncate_token_key_id(
-            &public_key_to_token_key_id::<CS::Group>(&server.get_public_key()),
-        );
+        let truncated_token_key_id =
+            truncate_token_key_id(&public_key_to_token_key_id::<CS>(&server.get_public_key()));
         key_store.insert(truncated_token_key_id, server).await;
         Ok(public_key)
     }

--- a/tests/kat_amortized.rs
+++ b/tests/kat_amortized.rs
@@ -87,7 +87,7 @@ async fn evaluate_kat<CS: PPCipherSuite>(list: Vec<AmortizedTokenTestVector>) {
         let public_key = server.set_key(&key_store, &vector.sk_s).await.unwrap();
 
         // KAT: Check public key
-        assert_eq!(serialize_public_key::<CS::Group>(public_key), vector.pk_s);
+        assert_eq!(serialize_public_key::<CS>(public_key), vector.pk_s);
 
         // Convert parameters
         let token_challenge =
@@ -212,7 +212,7 @@ async fn generate_kat_amortized_token<CS: PPCipherSuite>() -> AmortizedTokenTest
 
     let sk_s = <CS::Group as Group>::serialize_scalar(scalar).to_vec();
 
-    let pk_s = serialize_public_key::<CS::Group>(public_key);
+    let pk_s = serialize_public_key::<CS>(public_key);
 
     let redemption_context = if OsRng.next_u32() % 2 == 0 {
         let mut bytes = [0u8; 32];

--- a/tests/kat_private.rs
+++ b/tests/kat_private.rs
@@ -73,7 +73,7 @@ pub(crate) async fn evaluate_vector<CS: PPCipherSuite>(vector: PrivateTokenTestV
     let public_key = server.set_key(&key_store, &vector.sk_s).await.unwrap();
 
     // KAT: Check public key
-    assert_eq!(serialize_public_key::<CS::Group>(public_key), vector.pk_s);
+    assert_eq!(serialize_public_key::<CS>(public_key), vector.pk_s);
 
     // Convert parameters
     let token_challenge = TokenChallenge::deserialize(vector.token_challenge.as_slice()).unwrap();
@@ -176,7 +176,7 @@ pub(crate) async fn generate_kat_private_token<CS: PPCipherSuite>() -> PrivateTo
 
     let sk_s = <CS::Group as Group>::serialize_scalar(scalar).to_vec();
 
-    let pk_s = serialize_public_key::<CS::Group>(public_key);
+    let pk_s = serialize_public_key::<CS>(public_key);
 
     let redemption_context = if OsRng.next_u32() % 2 == 0 {
         let mut bytes = [0u8; 32];


### PR DESCRIPTION
 - Get rid of `Group` in public functions
 - Make `PPCipherSuite` thread-safe