### PR TITLE
fix: avoid panic

### DIFF
--- a/benches/public.rs
+++ b/benches/public.rs
@@ -167,7 +167,7 @@ pub fn criterion_public_benchmark(c: &mut Criterion) {
                         .unwrap();
                     origin_key_store
                         .insert(
-                            public_key_to_truncated_token_key_id(&public_key),
+                            public_key_to_truncated_token_key_id(&public_key).unwrap(),
                             public_key.clone(),
                         )
                         .await;

--- a/src/auth/authenticate.rs
+++ b/src/auth/authenticate.rs
@@ -77,7 +77,7 @@ impl TokenChallenge {
         if self.redemption_context.is_empty() {
             None
         } else {
-            Some(self.redemption_context.as_slice().try_into().unwrap())
+            self.redemption_context.as_slice().try_into().ok()
         }
     }
 

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -38,6 +38,13 @@ pub enum CreateKeypairError {
         #[source]
         source: BlindRsaError,
     },
+    #[error("Key serialization failed")]
+    /// Error when serializing the public key fails.
+    KeySerializationFailed {
+        /// Underlying RSA error that triggered the failure.
+        #[source]
+        source: BlindRsaError,
+    },
     #[error("Collision exhausted")]
     /// Error when collision attempts are exhausted
     CollisionExhausted,

--- a/src/common/private.rs
+++ b/src/common/private.rs
@@ -16,23 +16,19 @@ pub trait PrivateCipherSuite:
     + Sync
 {
     /// Returns the token type for the cipher suite.
+    fn token_type() -> TokenType;
+}
+
+impl PrivateCipherSuite for p384::NistP384 {
     fn token_type() -> TokenType {
-        match Self::ID {
-            "P384-SHA384" => TokenType::PrivateP384,
-            "ristretto255-SHA512" => TokenType::PrivateRistretto255,
-            _ => panic!("Unsupported token type"),
-        }
+        TokenType::PrivateP384
     }
 }
 
-impl<C> PrivateCipherSuite for C where
-    C: CipherSuite<Group: Group<Elem: Send + Sync, Scalar: Send + Sync>>
-        + PartialEq
-        + Debug
-        + Clone
-        + Send
-        + Sync
-{
+impl PrivateCipherSuite for voprf::Ristretto255 {
+    fn token_type() -> TokenType {
+        TokenType::PrivateRistretto255
+    }
 }
 
 /// Public key alias

--- a/src/generic_tokens/response.rs
+++ b/src/generic_tokens/response.rs
@@ -131,8 +131,12 @@ impl GenericBatchTokenResponse {
                     ) => response
                         .issue_token(state)
                         .map(GenericToken::from_private_ristretto)?,
-                    // The mismatch case is handled above.
-                    _ => unreachable!("token type mismatch checked earlier"),
+                    _ => {
+                        return Err(IssueTokenError::UnexpectedTokenResponseType {
+                            expected,
+                            found,
+                        });
+                    }
                 };
                 tokens.push(token);
             }

--- a/src/public_tokens/det_rng.rs
+++ b/src/public_tokens/det_rng.rs
@@ -76,11 +76,15 @@ impl TryRng for DeterministicRng {
     type Error = Infallible;
 
     fn try_next_u32(&mut self) -> Result<u32, Infallible> {
-        unimplemented!()
+        let mut buf = [0u8; 4];
+        self.fill_with_data(&mut buf)?;
+        Ok(u32::from_le_bytes(buf))
     }
 
     fn try_next_u64(&mut self) -> Result<u64, Infallible> {
-        unimplemented!()
+        let mut buf = [0u8; 8];
+        self.fill_with_data(&mut buf)?;
+        Ok(u64::from_le_bytes(buf))
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {

--- a/src/public_tokens/mod.rs
+++ b/src/public_tokens/mod.rs
@@ -4,6 +4,8 @@ use blind_rsa_signatures::{Deterministic, PSS, Sha384};
 use sha2::{Digest, Sha256};
 use typenum::U256;
 
+use blind_rsa_signatures::Error as BlindRsaError;
+
 use crate::{TokenKeyId, TruncatedTokenKeyId, auth::authorize::Token, truncate_token_key_id};
 
 pub mod request;
@@ -26,13 +28,20 @@ use self::server::serialize_public_key;
 /// Size of the authenticator
 pub const NK: usize = 256;
 
-/// Converts a public key to a token key ID
-pub fn public_key_to_truncated_token_key_id(public_key: &PublicKey) -> TruncatedTokenKeyId {
-    truncate_token_key_id(&public_key_to_token_key_id(public_key))
+/// Converts a public key to a truncated token key ID.
+///
+/// # Errors
+/// Returns an error if the public key cannot be serialized.
+pub fn public_key_to_truncated_token_key_id(
+    public_key: &PublicKey,
+) -> Result<TruncatedTokenKeyId, BlindRsaError> {
+    Ok(truncate_token_key_id(&public_key_to_token_key_id(
+        public_key,
+    )?))
 }
 
-fn public_key_to_token_key_id(public_key: &PublicKey) -> TokenKeyId {
-    let public_key = serialize_public_key(public_key);
+fn public_key_to_token_key_id(public_key: &PublicKey) -> Result<TokenKeyId, BlindRsaError> {
+    let public_key = serialize_public_key(public_key)?;
 
-    Sha256::digest(public_key).into()
+    Ok(Sha256::digest(public_key).into())
 }

--- a/src/public_tokens/request.rs
+++ b/src/public_tokens/request.rs
@@ -57,7 +57,11 @@ impl TokenRequest {
             .inspect_err(|e| warn!(error:% = e; "Failed to create challenge digest"))
             .map_err(|source| IssueTokenRequestError::InvalidTokenChallenge { source })?;
 
-        let token_key_id = public_key_to_token_key_id(&public_key);
+        let token_key_id = public_key_to_token_key_id(&public_key).map_err(|source| {
+            IssueTokenRequestError::BlindingError {
+                source: source.into(),
+            }
+        })?;
 
         // nonce = random(32)
         // challenge_digest = SHA256(challenge)

--- a/tests/generic_tokens.rs
+++ b/tests/generic_tokens.rs
@@ -67,7 +67,8 @@ async fn generic_tokens_cycle() {
         .insert(
             privacypass::public_tokens::public_key_to_truncated_token_key_id(
                 &public_token_public_key,
-            ),
+            )
+            .unwrap(),
             public_token_public_key.clone(),
         )
         .await;

--- a/tests/kat_public.rs
+++ b/tests/kat_public.rs
@@ -86,7 +86,7 @@ pub(crate) async fn evaluate_vector(vector: PublicTokenTestVector) {
     );
 
     // Serialize the public key and compare it
-    assert_eq!(serialize_public_key(&pub_key), vector.pk_s);
+    assert_eq!(serialize_public_key(&pub_key).unwrap(), vector.pk_s);
 
     let keypair = KeyPair {
         sk: sec_key,
@@ -94,12 +94,15 @@ pub(crate) async fn evaluate_vector(vector: PublicTokenTestVector) {
     };
 
     // Issuer server: Set the keypair
-    issuer_server.set_keypair(&issuer_key_store, keypair).await;
+    issuer_server
+        .set_keypair(&issuer_key_store, keypair)
+        .await
+        .unwrap();
 
     // Origin key store: Set the public key
     origin_key_store
         .insert(
-            public_key_to_truncated_token_key_id(&pub_key),
+            public_key_to_truncated_token_key_id(&pub_key).unwrap(),
             pub_key.clone(),
         )
         .await;
@@ -188,17 +191,18 @@ pub(crate) async fn generate_kat_public_token() -> PublicTokenTestVector {
     let keypair = KeyPair::<Sha384, PSS, Deterministic>::generate(&mut DefaultRng, 2048).unwrap();
 
     let sk_s = keypair.sk.to_pem().unwrap().into_bytes();
-    let pk_s = serialize_public_key(&keypair.pk);
+    let pk_s = serialize_public_key(&keypair.pk).unwrap();
 
     // Issuer server: Set the keypair
     issuer_server
         .set_keypair(&issuer_key_store, keypair.clone())
-        .await;
+        .await
+        .unwrap();
 
     // Origin key store: Set the public key
     origin_key_store
         .insert(
-            public_key_to_truncated_token_key_id(&keypair.pk),
+            public_key_to_truncated_token_key_id(&keypair.pk).unwrap(),
             keypair.pk.clone(),
         )
         .await;

--- a/tests/public_tokens.rs
+++ b/tests/public_tokens.rs
@@ -35,7 +35,7 @@ async fn public_tokens_cycle() {
 
     origin_key_store
         .insert(
-            public_key_to_truncated_token_key_id(&public_key),
+            public_key_to_truncated_token_key_id(&public_key).unwrap(),
             public_key.clone(),
         )
         .await;
@@ -117,7 +117,7 @@ async fn redeem_token_supports_multiple_public_keys_per_truncated_id() {
     };
     assert_eq!(
         truncated_token_key_id,
-        public_key_to_truncated_token_key_id(&initial_keypair.pk)
+        public_key_to_truncated_token_key_id(&initial_keypair.pk).unwrap()
     );
     issuer_key_store
         .insert(truncated_token_key_id, initial_keypair.clone())
@@ -155,7 +155,7 @@ async fn redeem_token_supports_multiple_public_keys_per_truncated_id() {
     };
     assert_eq!(
         truncated_token_key_id,
-        public_key_to_truncated_token_key_id(&rotated_keypair.pk)
+        public_key_to_truncated_token_key_id(&rotated_keypair.pk).unwrap()
     );
 
     origin_key_store


### PR DESCRIPTION
Remove all panic!(), unwrap(), unreachable!(), and unimplemented!() calls and propagate errors via `Result` instead of panicking, or turn runtime panics into compile-time errors where possible.